### PR TITLE
Failing deployment if no cluster_name provided

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -12,6 +12,10 @@ export function create(asgard_service) {
 
 
 internals.makeDeploymentInCluster = function(asgard_client, cluster_name, wait_until_complete) {
+  if (!cluster_name) {
+    return Promise.reject(new Error('Invalid cluster_name provided to makeDeploymentInCluster()'));
+  }
+
   return asgard_client
       .prepareDeployment(cluster_name)
       .then(prepared_deployment => {

--- a/test/acceptance/deployer-test.js
+++ b/test/acceptance/deployer-test.js
@@ -87,6 +87,15 @@ describe(__filename, () => {
 
       });
 
+      describe('without cluster_name', () => {
+        let cluster_name;
+
+        it('should fail', () => {
+          return deployer_instance.makeDeploymentInCluster(cluster_name, false).should.be.rejected();
+        });
+
+      });
+
     });
 
   });


### PR DESCRIPTION
Rejecting with a native Error to avoid dependency on error-factory.